### PR TITLE
More querying support needed by Topiary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "tree-sitter-facade"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["<herringtondarkholme@users.noreply.github.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,7 +6,7 @@ mod native {
     };
 
     pub struct Query {
-        pub inner: tree_sitter::Query,
+        pub(crate) inner: tree_sitter::Query,
     }
 
     impl Query {
@@ -36,6 +36,21 @@ mod native {
         pub fn general_predicates(&self, index: u32) -> Vec<QueryPredicate> {
             let index = index as usize;
             self.inner.general_predicates(index).iter().map(Into::into).collect()
+        }
+
+        #[inline]
+        pub fn pattern_count(&self) -> usize {
+            self.inner.pattern_count()
+        }
+
+        #[inline]
+        pub fn disable_pattern(&mut self, index: usize) -> () {
+            self.inner.disable_pattern(index)
+        }
+
+        #[inline]
+        pub fn start_byte_for_pattern(&self, pattern_index: usize) -> usize {
+            self.inner.start_byte_for_pattern(pattern_index)
         }
     }
 


### PR DESCRIPTION
- Expose more functions from rust bindings.
- Hide `Query.inner` behind `pub(crate)`.

The features provided by this PR has been successfully tested in https://github.com/tweag/topiary/pull/392